### PR TITLE
fix(webpack): remove css modules and add comments

### DIFF
--- a/config/webpack.common.config.js
+++ b/config/webpack.common.config.js
@@ -1,8 +1,10 @@
+// This is the common Webpack config. The dev and prod Webpack configs both
+// inherit config defined here.
 const path = require('path');
 
 module.exports = {
   entry: {
-    assets: path.resolve(__dirname, '../src/index.jsx'),
+    app: path.resolve(__dirname, '../src/index.jsx'),
   },
   output: {
     filename: '[name].js',

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -1,3 +1,5 @@
+// This is the dev Webpack config. All settings here should prefer a fast build
+// time at the expense of creating larger, unoptimized bundles.
 const Merge = require('webpack-merge');
 const path = require('path');
 const webpack = require('webpack');
@@ -13,7 +15,10 @@ module.exports = Merge.smart(commonConfig, {
     path.resolve(__dirname, '../src/index.jsx'),
   ],
   module: {
+    // Specify file-by-file rules to Webpack. Some file-types need a particular kind of loader.
     rules: [
+      // The babel-loader transforms newer ES2015+ syntax to older ES5 for older browsers.
+      // Babel is configured with the .babelrc file at the root of the project.
       {
         test: /\.(js|jsx)$/,
         include: [
@@ -21,23 +26,26 @@ module.exports = Merge.smart(commonConfig, {
         ],
         loader: 'babel-loader',
         options: {
+          // Caches result of loader to the filesystem. Future builds will attempt to read from the
+          // cache to avoid needing to run the expensive recompilation process on each run.
           cacheDirectory: true,
         },
       },
+      // We are not extracting CSS from the javascript bundles in development because extracting
+      // prevents hot-reloading from working, it increases build time, and we don't care about
+      // flash-of-unstyled-content issues in development.
       {
         test: /(.scss|.css)$/,
         use: [
-          'style-loader',
+          'style-loader', // creates style nodes from JS strings
           {
-            loader: 'css-loader',
+            loader: 'css-loader', // translates CSS into CommonJS
             options: {
               sourceMap: true,
-              modules: true,
-              localIdentName: '[local]',
             },
           },
           {
-            loader: 'sass-loader',
+            loader: 'sass-loader', // compiles Sass to CSS
             options: {
               sourceMap: true,
               includePaths: [
@@ -48,19 +56,27 @@ module.exports = Merge.smart(commonConfig, {
           },
         ],
       },
+      // Webpack, by default, uses the url-loader for images and fonts that are required/included by
+      // files it processes, which just base64 encodes them and inlines them in the javascript
+      // bundles. This makes the javascript bundles ginormous and defeats caching so we will use the
+      // file-loader instead to copy the files directly to the output directory.
       {
         test: /\.(woff2?|ttf|svg|eot)(\?v=\d+\.\d+\.\d+)?$/,
         loader: 'file-loader',
       },
     ],
   },
+  // Specify additional processing or side-effects done on the Webpack output bundles as a whole.
   plugins: [
+    // Generates an HTML file in the output directory.
     new HtmlWebpackPlugin({
-      inject: true,
+      inject: true, // Appends script tags linking to the webpack bundles at the end of the body
       template: path.resolve(__dirname, '../public/index.html'),
     }),
     new webpack.HotModuleReplacementPlugin(),
   ],
+  // This configures webpack-dev-server which serves bundles from memory and provides live
+  // reloading.
   devServer: {
     host: '0.0.0.0',
     port: 1991,

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -1,3 +1,5 @@
+// This is the prod Webpack config. All settings here should prefer smaller,
+// optimized bundles at the expense of a longer build time.
 const Merge = require('webpack-merge');
 const commonConfig = require('./webpack.common.config.js');
 const path = require('path');
@@ -7,10 +9,13 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 module.exports = Merge.smart(commonConfig, {
   devtool: 'source-map',
   output: {
-    filename: '[name].min.js',
+    filename: '[name].min.js', // adds ".min" to filename since we are using UglifyJS
   },
   module: {
+    // Specify file-by-file rules to Webpack. Some file-types need a particular kind of loader.
     rules: [
+      // The babel-loader transforms newer ES2015+ syntax to older ES5 for older browsers.
+      // Babel is configured with the .babelrc file at the root of the project.
       {
         test: /\.(js|jsx)$/,
         include: [
@@ -18,22 +23,31 @@ module.exports = Merge.smart(commonConfig, {
         ],
         loader: 'babel-loader',
       },
+      // Webpack, by default, includes all CSS in the javascript bundles. Unfortunately, that means:
+      // a) The CSS won't be cached by browsers separately (a javascript change will force CSS
+      // re-download).  b) Since CSS is applied asyncronously, it causes an ugly
+      // flash-of-unstyled-content.
+      //
+      // To avoid these problems, we extract the CSS from the bundles into separate CSS files that
+      // can be included as <link> tags in the HTML <head> manually.
+      //
+      // We will not do this in development because it prevents hot-reloading from working and it
+      // increases build time.
       {
         test: /(.scss|.css)$/,
         use: ExtractTextPlugin.extract({
+          // creates style nodes from JS strings, only used if extracting fails
           fallback: 'style-loader',
           use: [
             {
-              loader: 'css-loader',
+              loader: 'css-loader', // translates CSS into CommonJS
               options: {
                 sourceMap: true,
-                modules: true,
                 minimize: true,
-                localIdentName: '[local]',
               },
             },
             {
-              loader: 'sass-loader',
+              loader: 'sass-loader', // compiles Sass to CSS
               options: {
                 sourceMap: true,
                 includePaths: [
@@ -45,30 +59,48 @@ module.exports = Merge.smart(commonConfig, {
           ],
         }),
       },
+      // Webpack, by default, uses the url-loader for images and fonts that are required/included by
+      // files it processes, which just base64 encodes them and inlines them in the javascript
+      // bundles. This makes the javascript bundles ginormous and defeats caching so we will use the
+      // file-loader instead to copy the files directly to the output directory.
       {
         test: /\.(woff2?|ttf|svg|eot)(\?v=\d+\.\d+\.\d+)?$/,
         loader: 'file-loader',
       },
     ],
   },
+  // Specify additional processing or side-effects done on the Webpack output bundles as a whole.
   plugins: [
+    // CommonsChunkPlugin creates separate files with common modules shared between multiple entry
+    // points.
+    //
+    // This extracts all modules from node_modules to a common bundle called "vendor". It can be
+    // cached by users' browsers long-term and will only change if we upgrade a package.
     new webpack.optimize.CommonsChunkPlugin({
       name: 'vendor',
       minChunks: module => module.context && module.context.includes('node_modules'),
     }),
+    // Extracts the webpack bootstrap logic to a separate file. The contents of this file can change
+    // after every build, but are small in size.
     new webpack.optimize.CommonsChunkPlugin({
       name: 'manifest',
       minChunks: Infinity,
     }),
+    // Writes the extracted CSS from each entry to a file in the output directory.
     new ExtractTextPlugin({
       filename: '[name].min.css',
       allChunks: true,
     }),
+    // Defines a global variable that all bundles can access.
     new webpack.DefinePlugin({
       'process.env': {
+        // Maps the env var NODE_ENV at compile time to a global var available to bundles at
+        // runtime.  Should be set to "production" so that JS code knows it is running in a
+        // production environment.
         NODE_ENV: JSON.stringify(process.env.NODE_ENV),
       },
     }),
+    // Minifies the JS.
     new webpack.optimize.UglifyJsPlugin({ sourceMap: true }),
   ],
 });


### PR DESCRIPTION
Adds comments to the Webpack configs.

I also made a couple non-documentation changes:

1. Renamed the "assets" entry to "app". I think that was a copy-and-paste from studio-frontend.
2. Remove CSS modules config from the css-loader options.

`modules: true` paired with `localIdentName: [local]` doesn't change any class names. Also, I didn't see anything in this project that was importing CSS/Sass, so I don't think it is needed. I wouldn't want people copying it into their new projects unless they understood what it did and needed it. If this cookie cutter ever ends up using CSS modules, then we can add it back.