### PR TITLE
build(gh-pages): add publish command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -244,7 +244,7 @@
       "integrity": "sha512-erl8P4PwU+1jm/ah8PBhW6UE1MkNkzSTRJTMnFFewzVp4rOtrVNAhKbf4eGQ+52qoim3gN5aXVjHpexqy75/gg==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.6",
+        "@types/node": "9.4.7",
         "@types/tapable": "0.2.5",
         "@types/uglify-js": "2.6.30",
         "source-map": "0.6.1"
@@ -1768,6 +1768,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
       "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w==",
+      "dev": true
+    },
+    "base64url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
+      "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs=",
       "dev": true
     },
     "batch": {
@@ -4737,6 +4743,17 @@
         "readable-stream": "2.3.5"
       }
     },
+    "fs-extra": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.1"
+      }
+    },
     "fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
@@ -5851,6 +5868,42 @@
           "dev": true,
           "requires": {
             "prepend-http": "1.0.4"
+          }
+        }
+      }
+    },
+    "gh-pages": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-1.1.0.tgz",
+      "integrity": "sha512-ZpDkeOVmIrN5mz+sBWDz5zmTqcbNJzI/updCwEv/7rrSdpTNlj1B5GhBqG7f4Q8p5sJOdnBV0SIqxJrxtZQ9FA==",
+      "dev": true,
+      "requires": {
+        "async": "2.6.0",
+        "base64url": "2.0.0",
+        "commander": "2.11.0",
+        "fs-extra": "4.0.3",
+        "globby": "6.1.0",
+        "graceful-fs": "4.1.11",
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
+        },
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "dev": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         }
       }
@@ -8579,6 +8632,15 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -13971,6 +14033,12 @@
       "requires": {
         "imurmurhash": "0.1.4"
       }
+    },
+    "universalify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "repository": "https://github.com/jaebradley/edx-cookie-cutter",
   "scripts": {
     "build": "NODE_ENV=production BABEL_ENV=production webpack --config=config/webpack.prod.config.js",
+    "build:gh-pages": "NODE_ENV=development BABEL_ENV=development webpack --config=config/webpack.dev.config.js",
+    "deploy:gh-pages": "npm run build:gh-pages && gh-pages -d dist",
     "lint": "eslint --ext .js --ext .jsx .",
     "precommit": "npm run lint",
     "prepublishOnly": "npm run build",
@@ -49,6 +51,7 @@
     "extract-text-webpack-plugin": "next",
     "fetch-mock": "^6.0.0",
     "file-loader": "^1.1.9",
+    "gh-pages": "^1.1.0",
     "html-webpack-harddisk-plugin": "^0.2.0",
     "html-webpack-plugin": "^3.0.3",
     "husky": "^0.14.3",


### PR DESCRIPTION
Closes #14 

* Installs [the `gh-pages` package](https://www.npmjs.com/package/gh-pages)
* Adds an `npm` script (`npm run build:gh-pages`) that uses the development webpack configuration to build the files to push to gh-pages. I use the development webpack configuration since it bundles everything into one HTML and JS file.
* Adds an `npm` script (`npm run deploy:gh-pages`) that runs the `build:gh-pages` script and publishes the results to the `gh-pages` branch.