### PR TITLE
build(gh-pages): deploy production build to gh-pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 shell: ## run a shell on the cookie-cutter container
-	docker exec -it /bin/bash
+	docker exec -it edx.fecc /bin/bash
 
 build:
 	docker-compose build

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -4,12 +4,14 @@ const Merge = require('webpack-merge');
 const commonConfig = require('./webpack.common.config.js');
 const path = require('path');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = Merge.smart(commonConfig, {
   mode: 'production',
   devtool: 'source-map',
   output: {
-    filename: '[name].min.js',
+    filename: '[name].[chunkhash].js',
+    path: path.resolve(__dirname, '../dist'),
   },
   module: {
     // Specify file-by-file rules to Webpack. Some file-types need a particular kind of loader.
@@ -83,6 +85,11 @@ module.exports = Merge.smart(commonConfig, {
     new ExtractTextPlugin({
       filename: '[name].min.css',
       allChunks: true,
+    }),
+    // Generates an HTML file in the output directory.
+    new HtmlWebpackPlugin({
+      inject: true, // Appends script tags linking to the webpack bundles at the end of the body
+      template: path.resolve(__dirname, '../public/index.html'),
     }),
   ],
 });

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "repository": "https://github.com/jaebradley/edx-cookie-cutter",
   "scripts": {
     "build": "NODE_ENV=production BABEL_ENV=production webpack --config=config/webpack.prod.config.js",
-    "build:gh-pages": "NODE_ENV=development BABEL_ENV=development webpack --config=config/webpack.dev.config.js",
-    "deploy:gh-pages": "npm run build:gh-pages && gh-pages -d dist",
+    "deploy:gh-pages": "npm run build && gh-pages -d dist",
     "is-es5": "es-check es5 ./dist/*.js",
     "lint": "eslint --ext .js --ext .jsx .",
     "precommit": "npm run lint",


### PR DESCRIPTION
Webpack generates several JS files during our production build. This PR address issue #24 of getting our production build to properly inject the multiple files into `index.html` such that when the files are deployed to gh-pages, it will work as expected.

Running this locally, we can see from the screenshots that files with chunkhashes are being included in index.html and the 🍪 ✂️ app runs properly in the browser:

![files in client](https://user-images.githubusercontent.com/2828721/37845340-9e3d232a-2ea0-11e8-84b1-8e3e6d430f8c.png)
