### PR TITLE
fix(prod-build): adds missing html-webpack-plugin for production builds

### DIFF
--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -4,6 +4,7 @@ const Merge = require('webpack-merge');
 const commonConfig = require('./webpack.common.config.js');
 const path = require('path');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = Merge.smart(commonConfig, {
   mode: 'production',
@@ -105,6 +106,11 @@ module.exports = Merge.smart(commonConfig, {
     new ExtractTextPlugin({
       filename: '[name].min.css',
       allChunks: true,
+    }),
+    // Generates an HTML file in the output directory.
+    new HtmlWebpackPlugin({
+      inject: true, // Appends script tags linking to the webpack bundles at the end of the body
+      template: path.resolve(__dirname, '../public/index.html'),
     }),
   ],
 });


### PR DESCRIPTION
The usage of `html-webpack-plugin` was missing from our `config/webpack.prod.config.js` file, which prevented the CSS/JS from being injected into `index.html` on production builds. This is in the main `front-end-cookie-cutter` app so I'm not sure how it got removed in our branch. 🤷‍♂️

Related: The "flash of unstyled content" (FOUC) is only an issue when running the app locally with `webpack-dev-server` as it's loading all CSS within the Javascript which takes time to load into the DOM on initial page load. The production build extracts the CSS into their own files and injects them into `index.html`, so FOUC isn't an issue for production builds.

