### PR TITLE
Drop use of greenkeeper-lockfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,8 @@ notifications:
   on_success: never
 before_install:
   - npm install -g npm@latest
-  - npm install -g greenkeeper-lockfile@1.14.0
 install:
   - npm ci
-before_script: greenkeeper-lockfile-update
-after_script: greenkeeper-lockfile-upload
 script:
   - make validate-no-uncommitted-package-lock-changes
   - npm run lint

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ For more information, see [the `npm` documentation](https://docs.npmjs.com/files
 
 ### [`Greenkeeper`](https://greenkeeper.io/)
 
-[`Greenkeeper`](https://greenkeeper.io/) is basically a `GitHub` application that handles `npm` dependencies. It will automatically open PRs with `package.json` updates when new versions of your `npm` dependencies get published. There are ways to also automatically keep the `package-lock.json` in-line, in the same PR, using [`greenkeeper-lockfile`].
+[`Greenkeeper`](https://greenkeeper.io/) is basically a `GitHub` application that handles `npm` dependencies. It will automatically open PRs with `package.json` and `package-lock.json` updates when new versions of your `npm` dependencies get published.
 
 For more information, see [the `Greenkeeper` documentation](https://greenkeeper.io/docs.html#what-greenkeeper-does).
 

--- a/documentation/.travis.yml.md
+++ b/documentation/.travis.yml.md
@@ -26,23 +26,6 @@ This project uses a service called [`TravisBuddy`](https://www.travisbuddy.com/)
 
 ![travis-buddy](https://i.imgur.com/VsR2TTs.png)
 
-## Installing `greenkeeper-lockfile`
-
-As explained in [the `Greenkeeper` documentation](https://greenkeeper.io/docs.html#greenkeeper-step-by-step), `Greenkeeper` is a service that keeps track of your project's dependencies, and will, for example, automatically open PRs with an updated `package.json` file when the latest version of a dependency is a major version ahead of the existing dependency version in your `package.json` file.
-
-This automated updating is great, but `Greenkeeper` does not update your `package-lock.json` file, just your `package.json` file. This makes sense, as the only way to update the `package-lock.json` file would be to run `npm install` when building your project, using the latest `package.json`, and then committing the updated `package-lock.json` file.
-
-This is essentially what you have to do manually when `Greenkeeper` opens a PR - `git checkout` the branch, `npm install` locally, `git commit` the `package-lock.json` changes, and then `git push` those changes to the `Greenkeeper` branch on `origin`. It's fun probably only the first time, and even then it gets old, fast.
-
-What [`greenkeeper-lockfile`](https://github.com/greenkeeperio/greenkeeper-lockfile) does is that it automates the previous steps as part of the build process.
-
-It will
-  * Check that the branch is a `Greenkeeper` branch
-  * Update the lockfile
-  * Push a commit with the updated lockfile back to the Greenkeeper branch
-
-This is why it's important to install `greenkeeper-lockfile` in the `before_install` step, and since it's used exclusively only in the Travis Build, why it's not part of the package's dependencies.
-
 ## Scripts
 
 Most of the `script`s are self-explanatory - you probably want to fail a build if there are linting violations, or if any tests don't pass, or if it cannot compile your files.


### PR DESCRIPTION
Since late 2018, greenkeeper handles lockfiles for public packages itself.

https://blog.greenkeeper.io/announcing-native-lockfile-support-85381a37a0d0

Repos with private packages might still want greenkeeper-lockfile, but that can be a custom thing, rather than the default cookiecutter.