### PR TITLE
Add publicPath webpack setting so nested URLs can find assets

### DIFF
--- a/config/webpack.common.config.js
+++ b/config/webpack.common.config.js
@@ -8,6 +8,7 @@ module.exports = {
   },
   output: {
     path: path.resolve(__dirname, '../dist'),
+    publicPath: '/',
   },
   resolve: {
     extensions: ['.js', '.jsx'],


### PR DESCRIPTION
Without this, webpack will write relative urls for assets like CSS font url() methods.

And since CSS urls don't follow the `<base href="/">` specified in `<head>`, if your current URL is deeper than the toplevel, any local web font references or other url() method calls will not find their target. 

(It came up in publisher-frontend when trying to use FontAwesome webfonts.)