### PR TITLE
Adding fileMock.js for mocking static assets in Jest tests

### DIFF
--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';


### PR DESCRIPTION
Resolves issue #76 by adding `__mocks__/fileMock.js`.