### PR TITLE
Import font-awesome in App.scss

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1,2 +1,5 @@
 @import "~@edx/edx-bootstrap/sass/edx/theme";
 @import "~bootstrap/scss/bootstrap";
+
+$fa-font-path: "~font-awesome/fonts";
+@import "~font-awesome/scss/font-awesome";


### PR DESCRIPTION
When using Paragon components that use font-awesome icons (e.g., `<Icon />`) or just any font-awesome classes, they currently do not load until we include these 2 lines.